### PR TITLE
Fix selective-checkout stage snap tracking the edge channel

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,6 +128,6 @@ parts:
     build-packages:
       - git
     stage-snaps:
-      - selective-checkout/latest/edge
+      - selective-checkout
     prime:
       - -*


### PR DESCRIPTION
The stable channel recieves more QA than the edge channel.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>